### PR TITLE
fix rtc error when creating ticket with special character in description

### DIFF
--- a/IssueSyncTool/rtc_client.py
+++ b/IssueSyncTool/rtc_client.py
@@ -4,6 +4,7 @@ import urllib3
 from io import BytesIO
 from lxml import etree
 import os
+from xml.sax.saxutils import escape
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 def get_xml_tree(file_name, bdtd_validation=True):
@@ -596,6 +597,8 @@ Create a new work item.
       with open(os.path.join(self.templates_dir ,'workitem.xml')) as fh:
          workitem_template = fh.read()
 
+      title = escape(title)
+      description = escape(description)
       req_payload = workitem_template.format(**locals())
       # req_payload = workitem_template.format(
       #    project_id=project_id,

--- a/IssueSyncTool/rtc_client.py
+++ b/IssueSyncTool/rtc_client.py
@@ -304,7 +304,8 @@ Get the filed against URL for the specified file against name.
       """
       if not project_id:
          project_id = self.project['id']
-      url = f"{self.hostname}/ccm/oslc/categories?projectURL={self.hostname}/ccm/process/project-areas/{project_id}&oslc.select=dc:title,rdfs:member,rtc_cm:hierarchicalName"
+      # url = f"{self.hostname}/ccm/oslc/categories?projectURL={self.hostname}/ccm/process/project-areas/{project_id}&oslc.select=dc:title,rdfs:member,rtc_cm:hierarchicalName"
+      url = f"{self.hostname}/ccm/oslc/categories?oslc.where=rtc_cm:projectArea=\"{project_id}\"&oslc.select=dc:title,rdfs:member,rtc_cm:hierarchicalName"
       
       fileAgainst_url = self.__get_filedAgainst(url, fileAgainst_name)
       if not fileAgainst_url:


### PR DESCRIPTION
Hi Thomas,

Please review this change which fix rtc ticket creation error when ticket description contain xml special character.

Thank you,
Ngoan