### PR TITLE
fix issue when creating label for planning version

### DIFF
--- a/IssueSyncTool/sync_issue.py
+++ b/IssueSyncTool/sync_issue.py
@@ -434,7 +434,7 @@ Defined sync attributes:
    Logger.log(f"Updating {org_issue.tracker.title()} issue {org_issue.id}:", indent=4)
    if dest_issue.version:
       Logger.log(f"Adding sprint label '{dest_issue.version}'", indent=6)
-      org_tracker.create_label(dest_issue.version)
+      org_tracker.create_label(dest_issue.version, repository=org_issue.component)
       org_issue.update(labels=org_issue.labels+[dest_issue.version])
    else:
       Logger.log_warning(f"No version information from issue to be synced back", indent=6)

--- a/IssueSyncTool/tracker.py
+++ b/IssueSyncTool/tracker.py
@@ -1503,7 +1503,7 @@ Get the story points of an issue.
       # get story point from labels
       return self.get_story_point_from_labels(issue.labels)
 
-   def create_label(self, label_name: str, color: str = None, project: str = None):
+   def create_label(self, label_name: str, color: str = None, repository: str = None):
       """
 Create a new label in the Gitlab tracker.
 
@@ -1527,7 +1527,7 @@ Create a new label in the Gitlab tracker.
 
   The project name.
       """
-      gl_project = self.__get_project_client(project)
+      gl_project = self.__get_project_client(repository)
       list_existing_labels = gl_project.labels.list()
       for item in list_existing_labels:
          if item.name == label_name:


### PR DESCRIPTION
Hi Thomas,

This PR fixes current issue when sync planning information (as label) back to original trackers (Github, Gitlab, ...).

I have retired the daily job with this change, the planning is synced back to Github issues properly.
E.g for RobotFramework_AIO repo: https://github.com/test-fullautomation/RobotFramework_AIO/issues?q=state%3Aopen%20label%3A%22PI25.1.3%22

Please review and merge this change.

Thank you,
Ngoan