### PR TITLE
fix error due to wrong complexity definition of TAG RTC

### DIFF
--- a/IssueSyncTool/rtc_client.py
+++ b/IssueSyncTool/rtc_client.py
@@ -639,7 +639,16 @@ Get the complexity values for the specified project.
       complexity_dict = dict()
       list_complexity = res.json()['oslc:results']
       for item in list_complexity:
-         complexity_dict[item['dcterms:identifier']] = item['rdf:about']
+         # story_point = item['dcterms:identifier']  # Use identifier instead of title to avoid issues with non-integer titles
+         # Currently, TAG define the wrong title for complexity, so we need to use the title to get the correct story point value
+         try:
+            story_point = item['dcterms:title']
+            story_point = story_point.split(" ")[0]  # Get the first part of the title as the story point value
+            int(story_point)
+         except:
+            story_point = item['dcterms:identifier']
+
+         complexity_dict[story_point] = item['rdf:about']
 
       return complexity_dict
 


### PR DESCRIPTION
This PR fix the error when syncing the ticket with estimation `20 pts` to TAG RTC.
Currently, the definition of complexity in TAG RTC project is not proper for 20 point as below:
```
...
<rtc_cm:Literal rdf:resource="https://<rtc-host>/ccm/oslc/enumerations/_H_EmxWOGEe-u2fR_nAgXdQ/complexity/21">
  <dc:identifier>21</dc:identifier>
  <dc:title>20 pts</dc:title>
  <rtc_cm:iconUrl/>
</rtc_cm:Literal>
...
```
The identifier vs title of `20 pts` (only this definition) is inconsistent compare to the other definitions:
```
...
<rtc_cm:Literal rdf:resource="https://<rtc-host>/ccm/oslc/enumerations/_H_EmxWOGEe-u2fR_nAgXdQ/complexity/1">
  <dc:identifier>1</dc:identifier>
  <dc:title>1 pt</dc:title>
  <rtc_cm:iconUrl/>
</rtc_cm:Literal>
<rtc_cm:Literal rdf:resource="https://<rtc-host>/ccm/oslc/enumerations/_H_EmxWOGEe-u2fR_nAgXdQ/complexity/2">
  <dc:identifier>2</dc:identifier>
  <dc:title>2 pts</dc:title>
  <rtc_cm:iconUrl/>
</rtc_cm:Literal>
```

This PR try to get the title first to avoid that inconsistent.

Thank you,
Ngoan